### PR TITLE
Require explicit encryption key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Password Holder
+
+This project requires an encryption key for securing stored passwords.
+
+Set the `ENCRYPTION_KEY` environment variable before running the application:
+
+```bash
+export ENCRYPTION_KEY=your-secret-key
+python main.py
+```
+
+If the environment variable is not set, the application will prompt for the key using a secure input. If no key is provided, a `RuntimeError` is raised.

--- a/model/PasswordManager.py
+++ b/model/PasswordManager.py
@@ -1,5 +1,6 @@
 from model.Encrypter import Encrypter
 import os
+import getpass
 
 
 class PasswordManager:
@@ -8,7 +9,11 @@ class PasswordManager:
         if self.database:
             self.load_passwords()
         self.passwords = {}
-        self.encryption_key = os.getenv("ENCRYPTION_KEY", "default_key")
+        self.encryption_key = os.environ.get("ENCRYPTION_KEY")
+        if not self.encryption_key:
+            self.encryption_key = getpass.getpass("Enter encryption key: ")
+        if not self.encryption_key:
+            raise RuntimeError("ENCRYPTION_KEY not set")
         self.encrypter = Encrypter(self.encryption_key)
 
     def load_passwords(self):


### PR DESCRIPTION
## Summary
- Require an explicit encryption key from `ENCRYPTION_KEY` and prompt via `getpass` when missing
- Document `ENCRYPTION_KEY` requirement in README

## Testing
- `python -m py_compile model/PasswordManager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c43e31054832a87a1f82e8b355f3a