### PR TITLE
Secure key derivation with PBKDF2 and persistent salt

### DIFF
--- a/model/Encrypter.py
+++ b/model/Encrypter.py
@@ -1,15 +1,30 @@
 from cryptography.fernet import Fernet
 import base64
-import hashlib
+import os
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives import hashes
 
 
 class Encrypter:
-    def __init__(self, key):
-        # Generate a Fernet key from the provided password/key
-        key_bytes = key.encode()
-        key_hash = hashlib.sha256(key_bytes).digest()
-        # Fernet requires a 32-byte key encoded in base64
-        self.key = base64.urlsafe_b64encode(key_hash)
+    def __init__(self, key, salt_file="salt.bin"):
+        self.password = key
+        self.salt_file = salt_file
+
+        if os.path.exists(self.salt_file):
+            with open(self.salt_file, "rb") as f:
+                salt = f.read()
+        else:
+            salt = os.urandom(16)
+            with open(self.salt_file, "wb") as f:
+                f.write(salt)
+
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=salt,
+            iterations=100000,
+        )
+        self.key = base64.urlsafe_b64encode(kdf.derive(self.password.encode()))
         self.cipher = Fernet(self.key)
 
     def encrypt(self, data):
@@ -21,9 +36,17 @@ class Encrypter:
         return encrypted_data
 
     def decrypt(self, data):
-        # Decrypt the data
-        decrypted_data = self.cipher.decrypt(data)
-        # Try to decode to string if possible
+        with open(self.salt_file, "rb") as f:
+            salt = f.read()
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=salt,
+            iterations=100000,
+        )
+        key = base64.urlsafe_b64encode(kdf.derive(self.password.encode()))
+        cipher = Fernet(key)
+        decrypted_data = cipher.decrypt(data)
         try:
             return decrypted_data.decode()
         except UnicodeDecodeError:


### PR DESCRIPTION
## Summary
- Derive Fernet keys using PBKDF2HMAC with a stored 16-byte salt and 100k iterations
- Re-derive keys during decryption using the persisted salt

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689c43dc5edc832a889a09aced9b21ee