### PR TITLE
Restrict database file permissions

### DIFF
--- a/model/PasswordDatabase.py
+++ b/model/PasswordDatabase.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 
 
@@ -7,6 +8,10 @@ class PasswordDatabase:
             raise ValueError("Database name must be provided")
         self.db_name = db_name
         self.create_table()
+        try:
+            os.chmod(self.db_name, 0o600)
+        except FileNotFoundError:
+            pass
         self.connection = None
 
     def connect(self):


### PR DESCRIPTION
## Summary
- limit database file permissions to owner with `os.chmod`
- handle missing database file gracefully

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c43f086fc832a847703f36848f276