### PR TITLE
Fix connection management in password manager

### DIFF
--- a/model/PasswordManager.py
+++ b/model/PasswordManager.py
@@ -17,7 +17,6 @@ class PasswordManager:
         self.database.disconnect()
 
     def add_password(self, service, password):
-        self.database.connect()
         self.database.add_password(service, self.encrypter.encrypt(password))
         self.passwords[service] = self.encrypter.encrypt(password)
 
@@ -28,10 +27,8 @@ class PasswordManager:
         return None
 
     def remove_password(self, service):
-        self.database.connect()
         self.database.remove_password(service)
         self.passwords.pop(service, None)
-        self.database.disconnect()
 
     def get_passwords(self):
         return {


### PR DESCRIPTION
## Summary
- avoid redundant connection usage in password manager
- rely on database methods to open/close connections for add/remove password

## Testing
- `pytest`
- `python -m py_compile model/PasswordManager.py`


------
https://chatgpt.com/codex/tasks/task_e_689c43f59640832aac4a6628b8fa9583